### PR TITLE
Add linear interpolation for continuous strokes 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ build:
 	@mkdir -p build 
 	@cd build && cmake .. && make all && ./drawww
 
+.PHONY: clean
+clean:
+	@rm -rf build
+
 # Debugs runtime errors using the lldb debugger
 .PHONY: debug
 debug:

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -32,44 +32,118 @@ const char *RENDER_CONTEXT_NATIVE = "native";
  * 3. Finally, we update the viewport with the new updated framebuffer size.
  * @param window The GLFW window
  */
-void applyEmscriptenCanvasResize(GLFWwindow * window) {
-  // 1. Get canvas container size in CSS pixels and set HTML canvas element size to span its
-  // container element dimensions in CSS pixels
-  double canvasContainerWidth, canvasContainerHeight;
+void applyEmscriptenCanvasResize(GLFWwindow *window) {
+    // 1. Get canvas container size in CSS pixels and set HTML canvas element size to span its
+    // container element dimensions in CSS pixels
+    double canvasContainerWidth, canvasContainerHeight;
 
-  emscripten_get_element_css_size("#canvas-container", &canvasContainerWidth, &canvasContainerHeight);
-  emscripten_set_canvas_element_size("canvas", int(canvasContainerWidth), int(canvasContainerHeight));
+    emscripten_get_element_css_size("#canvas-container", &canvasContainerWidth, &canvasContainerHeight);
+    emscripten_set_canvas_element_size("canvas", int(canvasContainerWidth), int(canvasContainerHeight));
 
-  // 2. Set the GLFW window size based on the updated canvas pixel size
-  // This will cause the frame buffer size to be recalculated.
-  glfwSetWindowSize(window, int(canvasContainerWidth), int(canvasContainerHeight));
+    // 2. Set the GLFW window size based on the updated canvas pixel size
+    // This will cause the frame buffer size to be recalculated.
+    glfwSetWindowSize(window, int(canvasContainerWidth), int(canvasContainerHeight));
 
-  // 3. Finally update the viewport with the updated frame buffer size
-  int frameBufferWidth, frameBufferHeight;
-  glfwGetFramebufferSize(window, &frameBufferWidth, &frameBufferHeight);
+    // 3. Finally update the viewport with the updated frame buffer size
+    int frameBufferWidth, frameBufferHeight;
+    glfwGetFramebufferSize(window, &frameBufferWidth, &frameBufferHeight);
 
-  glViewport(0, 0, frameBufferWidth, frameBufferHeight);
+    glViewport(0, 0, frameBufferWidth, frameBufferHeight);
 }
 
 /**
  * emscriptenResizeCallback handles the HTML window being resized
  */
 bool emscriptenResizeCallback(int eventType, const EmscriptenUiEvent *uiEvent, void *userData) {
-  GLFWwindow *window = reinterpret_cast<GLFWwindow *>(userData);
-  if (!window) return false;
+    GLFWwindow *window = reinterpret_cast<GLFWwindow *>(userData);
+    if (!window) return false;
 
-  applyEmscriptenCanvasResize(window);
+    applyEmscriptenCanvasResize(window);
 
-  return true;
+    return true;
 }
 #endif
 
+// engineMouseButtonCallback is a callback handler called each time the mouse button is pressed or released.
+// We update the draw state accordingly based on the given button event.
+void engineMouseButtonCallback(GLFWwindow *window, int button, int action, int mods) {
+    auto engine = reinterpret_cast<Engine *>(glfwGetWindowUserPointer(window));
+
+    if (action == GLFW_PRESS) {
+        engine->setDrawing(true);
+        engine->addPointAtMousePosition();
+    } else if (action == GLFW_RELEASE) {
+        engine->setDrawing(false);
+    }
+}
+
+// engineCursorPositionCallback is a callback handler called each time the mouse button is moved within the window.
+// We linearly interpolate the distance between the __last known position__ in a given draw session and the __current mouse position__.
+// A draw session is created when the user starts pressing down on the mouse, and it is cleared when the mouse is released.
+// This approach allows us to minimize the gaps in stroke lines when drawing continuously.
+void engineCursorPositionCallback(GLFWwindow *window, double xpos, double ypos) {
+    auto engine = reinterpret_cast<Engine *>(glfwGetWindowUserPointer(window));
+
+    if (!engine->isDrawing()) {
+        return;
+    };
+
+    glm::vec2 mousePositionFrameBuffer = getMousePositionFrameBuffer(window);
+
+    if (!engine->hasLastPoint) {
+        engine->lastPoint = glm::vec2{mousePositionFrameBuffer.x, mousePositionFrameBuffer.y};
+        engine->hasLastPoint = true;
+
+        // Return early as there's nothing to do.
+        // We have only just started drawing
+        return;
+    }
+
+    // Compute the distance between the current position and the last point
+    auto dx = mousePositionFrameBuffer.x - engine->lastPoint.x;
+    auto dy = mousePositionFrameBuffer.y - engine->lastPoint.y;
+
+    auto euclidian_distance = std::sqrt(dx * dx + dy * dy);
+
+    if (euclidian_distance <= 0) {
+        // Nothing to interpolate
+        return;
+    }
+
+    float gapSize = 10;
+    int interpolationSteps = std::ceil(euclidian_distance / gapSize);
+
+    if (engine->debugMode) {
+        printf("Num interpolation steps => %d\n", interpolationSteps);
+    }
+
+    // Perform the linear interpolation and add points accordingly
+    for (int i = 1; i <= interpolationSteps; i++) {
+        double t = double(i) / double(interpolationSteps);
+
+        auto pointPosX = engine->lastPoint.x + (dx * t);
+        auto pointPosY = engine->lastPoint.y + (dy * t);
+
+        auto pointPositionNDC = frameBufferPosToNDC(glm::vec2{pointPosX, pointPosY});
+
+        // Add a new point at this position
+        std::unique_ptr<Point> point(new Point(pointPositionNDC.x, pointPositionNDC.y));
+
+        engine->add(std::move(point));
+    }
+
+    // Set this position as the last known position in the drawing session (i.e mouse press)
+    engine->lastPoint = glm::vec2{mousePositionFrameBuffer.x, mousePositionFrameBuffer.y};
+}
+
 // Initialises the engine
 Engine::Engine(int width, int height, const char *title) {
-  this->setRenderContext();
-  this->createWindow(width, height, title);
-  this->initOpenGL();
-  this->registerCallbacks();
+    this->setRenderContext();
+    this->createWindow(width, height, title);
+    this->initOpenGL();
+    this->registerCallbacks();
+
+    this->setDrawing(false);
 }
 
 // Destructor to clean up heap-allocated objects
@@ -77,156 +151,98 @@ Engine::~Engine() { this->nodes.clear(); }
 
 void Engine::setRenderContext() {
 #ifdef __EMSCRIPTEN__
-  this->context = RENDER_CONTEXT_WEB;
+    this->context = RENDER_CONTEXT_WEB;
 #else
-  this->context = RENDER_CONTEXT_NATIVE;
+    this->context = RENDER_CONTEXT_NATIVE;
 #endif
 }
 
 void Engine::setDrawing(bool isDrawing) {
-  this->_isDrawing = isDrawing;
+    this->_isDrawing = isDrawing;
 
-  if (!isDrawing) {
-    this->hasLastPoint = false;
-  } else {
-    printf("SET DRAWING!!!!\n");
-  }
+    if (!isDrawing) {
+        // Reset last point if we are not drawing
+        this->hasLastPoint = false;
+    }
 }
 
 bool Engine::isDrawing() {
-  return this->_isDrawing;
+    return this->_isDrawing;
 }
 
-void engineMouseButtonCallback(GLFWwindow* window, int button, int action, int mods) {
-  auto engine = reinterpret_cast<Engine *>(glfwGetWindowUserPointer(window));
+// addPointAtMousePosition adds a point at the current mouse position
+void Engine::addPointAtMousePosition() {
+    glm::vec2 mousePositionNDC = getMousePositionNDC(window);
 
-  switch (action){
-    case GLFW_PRESS:
-      engine->setDrawing(true);
-      break;
-    case GLFW_RELEASE:
-      engine->setDrawing(false);
-      break;
-  }
+    std::unique_ptr<Point> point(new Point(mousePositionNDC.x, mousePositionNDC.y));
 
-  printf("Is drawing: %s \n", engine->isDrawing() ? "true":"false");
+    this->add(std::move(point));
 }
 
-void engineCursorPositionCallback(GLFWwindow* window, double xpos, double ypos) {
-  auto engine = reinterpret_cast<Engine *>(glfwGetWindowUserPointer(window));
-
-  if (!engine->isDrawing()) {
-    return;
-  };
-
-  glm::vec2 mousePositionNDC = getMousePositionNDC(window);
-
-  // printf("Drawing at Window position: %f %f. NDC: %f %f\n", xpos, ypos, mousePositionNDC.x, mousePositionNDC.y);
-
-  if (!engine->hasLastPoint) {
-    engine->lastPoint = glm::vec2{mousePositionNDC.x, mousePositionNDC.y};
-    engine->hasLastPoint = true;
-
-    // Return early as there's nothing to do
-    return;
-  }
-
-  // Compute the distance between the current position and the last point
-  auto dx = mousePositionNDC.x - engine->lastPoint.x;
-  auto dy = mousePositionNDC.y - engine->lastPoint.y;
-
-  auto distance = std::sqrt(dx * dx + dy * dy);
-
-  printf("Distanceee: x=%f y=%f distance=%f\n", dx, dy, distance);
-
-  if (distance <= 0) {
-    // Nothing to interpolate
-    return;
-  }
-
-  float seperator = 1;
-
-  int steps = std::ceil(distance / seperator);
-
-  for (int i = 1; i <= steps; i++) {
-  double t = double(i) / double(steps);
-
-    auto new_x = engine->lastPoint.x + (dx * t);
-    auto new_y = engine->lastPoint.y + (dy * t);
-
-    // Add a new point at this position
-    std::unique_ptr<Point> point(new Point(new_x, new_y));
-
-    engine->add(std::move(point));
-  }
-
-  // Set this position as the last
-  engine->lastPoint = glm::vec2{mousePositionNDC.x, mousePositionNDC.y};
-}
-
+// registerCallbacks registers a set of window callbacks
 void Engine::registerCallbacks() {
-  glfwSetMouseButtonCallback(window, engineMouseButtonCallback);
-  glfwSetCursorPosCallback(window, engineCursorPositionCallback);
+    glfwSetMouseButtonCallback(window, engineMouseButtonCallback);
+    glfwSetCursorPosCallback(window, engineCursorPositionCallback);
 }
 
 // createWindow creates a window for the engine
 void Engine::createWindow(int width, int height, const char *title) {
-  // Setup the GLFW library
-  glfwInit();
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-  glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+    // Setup the GLFW library
+    glfwInit();
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 
-  // Create the GLFW window
-  GLFWwindow *_window = glfwCreateWindow(width, height, title, nullptr, nullptr);
-  if (_window == nullptr) {
-    std::cout << "Failed to create GLFW window" << std::endl;
-    glfwTerminate();
+    // Create the GLFW window
+    GLFWwindow *_window = glfwCreateWindow(width, height, title, nullptr, nullptr);
+    if (_window == nullptr) {
+        std::cout << "Failed to create GLFW window" << std::endl;
+        glfwTerminate();
 
-    throw std::runtime_error("failed to create window");
-  }
+        throw std::runtime_error("failed to create window");
+    }
 
-  // Store a reference to the window in the engine instance
-  this->window = _window;
-  this->title = title;
+    // Store a reference to the window in the engine instance
+    this->window = _window;
+    this->title = title;
 
-  // Set a reference to the drawww engine instance in GLFW.
-  // This allows us to reference the engine instance later on in callbacks
-  glfwSetWindowUserPointer(_window, this);
+    // Set a reference to the drawww engine instance in GLFW.
+    // This allows us to reference the engine instance later on in callbacks
+    glfwSetWindowUserPointer(_window, this);
 
-  // Make the created window the GLFW current context
-  glfwMakeContextCurrent(this->window);
+    // Make the created window the GLFW current context
+    glfwMakeContextCurrent(this->window);
 }
 
 // initOpenGL intialises OpenGL
 void Engine::initOpenGL() {
-  // Load the OpenGl function points with GLAD
-  if (!gladLoadGL(glfwGetProcAddress)) {
-    std::cout << "Failed to initialize GLAD" << std::endl;
+    // Load the OpenGl function points with GLAD
+    if (!gladLoadGL(glfwGetProcAddress)) {
+        std::cout << "Failed to initialize GLAD" << std::endl;
 
-    throw std::runtime_error("failed to load OpenGL functions");
-  }
+        throw std::runtime_error("failed to load OpenGL functions");
+    }
 
-  // Set the OpenGL viewport
-  int frameBufferWidth, frameBufferHeight;
-  glfwGetFramebufferSize(this->window, &frameBufferWidth, &frameBufferHeight);
-  glViewport(0, 0, frameBufferWidth, frameBufferHeight);
+    // Set the OpenGL viewport
+    int frameBufferWidth, frameBufferHeight;
+    glfwGetFramebufferSize(this->window, &frameBufferWidth, &frameBufferHeight);
+    glViewport(0, 0, frameBufferWidth, frameBufferHeight);
 
-  // Register GLFW callback on native platforms
-  glfwSetFramebufferSizeCallback(this->window, glfwFramebufferSizeCallback);
+    // Register GLFW callback on native platforms
+    glfwSetFramebufferSizeCallback(this->window, glfwFramebufferSizeCallback);
 
-  // Register emscripten callbacks
+    // Register emscripten callbacks
 #ifdef __EMSCRIPTEN__
-  applyEmscriptenCanvasResize(this->window);
-  emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this->window, false, emscriptenResizeCallback);
+    applyEmscriptenCanvasResize(this->window);
+    emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this->window, false, emscriptenResizeCallback);
 #endif
 }
 
 // glfwFramebufferSizeCallback is callback handler that is called each time the GLFW
 // window is resized
 void glfwFramebufferSizeCallback(GLFWwindow *window, int width, int height) {
-  glViewport(0, 0, width, height);
+    glViewport(0, 0, width, height);
 }
 
 // run runs the engine render loop.
@@ -234,10 +250,10 @@ void glfwFramebufferSizeCallback(GLFWwindow *window, int width, int height) {
 // otherwise we use the engine's native render loop.
 void Engine::run() {
 #ifdef __EMSCRIPTEN__
-  emscripten_set_main_loop_arg(runWeb, this, 0, true);
+    emscripten_set_main_loop_arg(runWeb, this, 0, true);
 #else
-  // We are in a native context, so run the render loop
-  this->runNative();
+    // We are in a native context, so run the render loop
+    this->runNative();
 #endif
 }
 
@@ -245,40 +261,40 @@ void Engine::run() {
 // The function is called per frame by the browser and yields back control after
 // a single render pass.
 static void runWeb(void *userData) {
-  Engine *engine = reinterpret_cast<Engine *>(userData);
-  if (engine == nullptr)
-    return;
+    Engine *engine = reinterpret_cast<Engine *>(userData);
+    if (engine == nullptr)
+        return;
 
-  engine->tick();
+    engine->tick();
 }
 
 // runNative runs the render loop on a native platform.
 // The loop runs until the end of the program.
 void Engine::runNative() {
-  while (this->isRunning()) {
-    this->tick();
-  }
+    while (this->isRunning()) {
+        this->tick();
+    }
 }
 
 // tick is a single render pass used to draw on the screen.
 void Engine::tick() {
-  // Record metrics at the start of each frame
-  this->recordMetrics();
+    // Record metrics at the start of each frame
+    this->recordMetrics();
 
-  // Process input within the engine
-  this->processInput();
+    // Process input within the engine
+    this->processInput();
 
-  // Clear the screen
-  this->clearScreen();
+    // Clear the screen
+    this->clearScreen();
 
-  // Draw the objects
-  this->render();
+    // Draw the objects
+    this->render();
 
-  // Swap buffers to render the draw calls
-  glfwSwapBuffers(this->window);
+    // Swap buffers to render the draw calls
+    glfwSwapBuffers(this->window);
 
-  // Poll for events i.e process all pending OpenGL events
-  glfwPollEvents();
+    // Poll for events i.e process all pending OpenGL events
+    glfwPollEvents();
 }
 
 // isRunning indicates if the engine is running
@@ -286,59 +302,41 @@ bool Engine::isRunning() { return !glfwWindowShouldClose(window); }
 
 // processInput processes input from the window on each render loop
 void Engine::processInput() {
-  int keyboardExitCode = processKeyboardInput();
-  if (keyboardExitCode == -1)
-    return;
-
-  processMouseInput();
+    int keyboardExitCode = processKeyboardInput();
+    if (keyboardExitCode == -1)
+        return;
 }
 
 // processKeyboardInput processes keyboard input from the window on each render
 // loop
 int Engine::processKeyboardInput() {
-  if (glfwGetKey(this->window, GLFW_KEY_ESCAPE) == GLFW_PRESS) {
-    glfwSetWindowShouldClose(this->window, true);
-    utils::print("👋🏽 Closing");
+    if (glfwGetKey(this->window, GLFW_KEY_ESCAPE) == GLFW_PRESS) {
+        glfwSetWindowShouldClose(this->window, true);
+        utils::print("👋🏽 Closing");
 
-    return -1;
-  }
+        return -1;
+    }
 
-  return 0;
-}
-
-// processMouseInput processes mouse input from the window on each render loop
-void Engine::processMouseInput() {
-  // Add a new point if the mouse is currently pressed
-  // int leftMouseButtonState =
-  //     glfwGetMouseButton(this->window, GLFW_MOUSE_BUTTON_LEFT);
-  // if (leftMouseButtonState != GLFW_PRESS)
-  //   return;
-  //
-  // glm::vec2 mousePositionNDC = getMousePositionNDC(this->window);
-  //
-  // std::unique_ptr<Point> point(
-  //     new Point(mousePositionNDC.x, mousePositionNDC.y));
-  //
-  // this->add(std::move(point));
+    return 0;
 }
 
 // clearScreen clears the screen
 void Engine::clearScreen() {
-  glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
-  glClear(GL_COLOR_BUFFER_BIT);
+    glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
 }
 
 // add adds a drawable item to the engine's scene graph
 void Engine::add(std::unique_ptr<Drawable> node) {
-  this->nodes.push_back(std::move(node));
+    this->nodes.push_back(std::move(node));
 }
 
 // render renders the nodes in the engine's scene graph
 // Todo: Optimise how points are drawn, so we use a single draw call per frame.
 void Engine::render() {
-  for (std::unique_ptr<Drawable> &node : this->nodes) {
-    node->draw();
-  }
+    for (std::unique_ptr<Drawable> &node: this->nodes) {
+        node->draw();
+    }
 }
 
 // Terminates the window and engine
@@ -346,42 +344,44 @@ void Engine::terminate() { glfwTerminate(); }
 
 // recordMetrics records metrics (e.g FPS) on each iteration of the render loop.
 void Engine::recordMetrics() {
-  double now = glfwGetTime();
+    double now = glfwGetTime();
 
-  if (this->lastCheckpointTime == 0.0) {
-    this->lastCheckpointTime = now;
-    return;
-  }
+    if (this->lastCheckpointTime == 0.0) {
+        this->lastCheckpointTime = now;
+        return;
+    }
 
-  this->numFrames += 1;
+    this->numFrames += 1;
 
-  // Update the FPS metric if it's been more than 1 second since
-  // the last time the metric was recorded
-  double elapsedTime = now - this->lastCheckpointTime;
-  if (elapsedTime < 1.0) {
-    return;
-  }
+    // Update the FPS metric if it's been more than 1 second since
+    // the last time the metric was recorded
+    double elapsedTime = now - this->lastCheckpointTime;
+    if (elapsedTime < 1.0) {
+        return;
+    }
 
-  // This assumes that elapsed time is either 1 second or close to that
-  double milliSecondsPerFrame = (elapsedTime * 1000) / double(numFrames);
-  double framesPerSecond = double(this->numFrames) / elapsedTime;
-  int fps = int(std::floor(framesPerSecond));
+    // This assumes that elapsed time is either 1 second or close to that
+    double milliSecondsPerFrame = (elapsedTime * 1000) / double(numFrames);
+    double framesPerSecond = double(this->numFrames) / elapsedTime;
+    int fps = int(std::floor(framesPerSecond));
 
-  // Build the window title containing the metrics.
-  // We only update the window title with this information on non-web platforms
-  std::stringstream windowTitle;
-  windowTitle.setf(std::ios::fixed);
-  windowTitle << this->title << " @ " << fps << " FPS — "
-              << std::setprecision(3) << milliSecondsPerFrame << "ms/frame";
+    // Build the window title containing the metrics.
+    // We only update the window title with this information on non-web platforms
+    std::stringstream windowTitle;
+    windowTitle.setf(std::ios::fixed);
+    windowTitle << this->title << " @ " << fps << " FPS — "
+            << std::setprecision(3) << milliSecondsPerFrame << "ms/frame";
 
 #ifndef  __EMSCRIPTEN__
-  glfwSetWindowTitle(window, windowTitle.str().c_str());
+    glfwSetWindowTitle(window, windowTitle.str().c_str());
 #endif
 
-  // Print metrics to stdout
-  // printf("%i FPS - %.3f ms/frame\n", fps, milliSecondsPerFrame);
 
-  // Reset the metrics for the next second
-  this->numFrames = 0;
-  this->lastCheckpointTime = now;
+    if (this->debugMode) {
+        printf("%i FPS - %.3f ms/frame\n", fps, milliSecondsPerFrame);
+    }
+
+    // Reset the metrics for the next second
+    this->numFrames = 0;
+    this->lastCheckpointTime = now;
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -32,7 +32,26 @@ public:
   // This could either be web or native
   void setRenderContext();
 
+  // registerCallbacks registers a set of callbacks
+  void registerCallbacks();
+
+  void setDrawing(bool isDrawing);
+
+  bool isDrawing();
+
+  // Indicates the last drawn point
+  glm::vec2 lastPoint;
+  bool hasLastPoint;
+
 private:
+  // This allows us enable debug logs
+  bool debugMode;
+
+  // Indicates if we are currently drawing
+  bool _isDrawing;
+
+
+
   // context describes the render context of the engine e.g web or native
   const char * context;
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -10,101 +10,101 @@
 // state of the main loop and the app window
 class Engine {
 public:
-  // Initialises the engine
-  Engine(int width, int height, const char *title);
+    // Initialises the engine
+    Engine(int width, int height, const char *title);
 
-  // Destructor to clean up heap-allocated objects
-  ~Engine();
+    // Destructor to clean up heap-allocated objects
+    ~Engine();
 
-  // add adds a drawable item to the engine's scene graph
-  void add(std::unique_ptr<Drawable> node);
+    // add adds a drawable item to the engine's scene graph
+    void add(std::unique_ptr<Drawable> node);
 
-  // run runs the engine render loop
-  void run();
+    // run runs the engine render loop
+    void run();
 
-  // tick is a single render pass used to draw on the screen.
-  void tick();
+    // tick is a single render pass used to draw on the screen.
+    void tick();
 
-  // Terminates the engine and window
-  void terminate();
+    // Terminates the engine and window
+    void terminate();
 
-  // setRenderContext sets the context in which the engine is running in.
-  // This could either be web or native
-  void setRenderContext();
+    // setRenderContext sets the context in which the engine is running in.
+    // This could either be web or native
+    void setRenderContext();
 
-  // registerCallbacks registers a set of callbacks
-  void registerCallbacks();
+    // registerCallbacks registers a set of window callbacks
+    void registerCallbacks();
 
-  void setDrawing(bool isDrawing);
+    // setDrawing sets the drawing state of the engine
+    void setDrawing(bool isDrawing);
 
-  bool isDrawing();
+    // isDrawing indicates whether we are currently drawing i.e is the mouse pressed.
+    bool isDrawing();
 
-  // Indicates the last drawn point
-  glm::vec2 lastPoint;
-  bool hasLastPoint;
+    // addPointAtMousePosition adds a point at the current mouse position
+    void addPointAtMousePosition();
+
+    // Indicates the last drawn point
+    glm::vec2 lastPoint;
+    bool hasLastPoint;
+
+    // This allows us enable debug logs
+    bool debugMode;
 
 private:
-  // This allows us enable debug logs
-  bool debugMode;
+    // Indicates if we are currently drawing
+    bool _isDrawing;
 
-  // Indicates if we are currently drawing
-  bool _isDrawing;
+    // context describes the render context of the engine e.g web or native
+    const char *context;
 
+    /**
+      Observability-related fields
+    */
+    double lastCheckpointTime;
+    int numFrames;
 
+    /**
+      Engine metadata
+     */
+    const char *title;
 
-  // context describes the render context of the engine e.g web or native
-  const char * context;
+    /**
+      Core engine fields and methods
+    */
+    // The window used by the engine
+    GLFWwindow *window;
 
-  /**
-    Observability-related fields
-  */
-  double lastCheckpointTime;
-  int numFrames;
+    // The nodes which will be rendered in the sceene
+    std::vector<std::unique_ptr<Drawable> > nodes;
 
-  /**
-    Engine metadata
-   */
-  const char *title;
+    // createWindow creates a window for the engine
+    void createWindow(int width, int height, const char *title);
 
-  /**
-    Core engine fields and methods
-  */
-  // The window used by the engine
-  GLFWwindow *window;
+    // initOpenGL intiialises OpenGL
+    void initOpenGL();
 
-  // The nodes which will be rendered in the sceene
-  std::vector<std::unique_ptr<Drawable>> nodes;
+    // isRunning indicates if the engine is running
+    bool isRunning();
 
-  // createWindow creates a window for the engine
-  void createWindow(int width, int height, const char *title);
+    // processInput processes input from the window on each render loop
+    void processInput();
 
-  // initOpenGL intiialises OpenGL
-  void initOpenGL();
+    // processKeyboardInput processes keyboard input from the window on each
+    // render loop
+    int processKeyboardInput();
 
-  // isRunning indicates if the engine is running
-  bool isRunning();
+    // clearScreen clears the screen
+    void clearScreen();
 
-  // processInput processes input from the window on each render loop
-  void processInput();
+    // render renders the nodes in the engine's scene graph
+    void render();
 
-  // processKeyboardInput processes keyboard input from the window on each
-  // render loop
-  int processKeyboardInput();
+    // recordMetrics records metrics on each iteration of the render loop.
+    void recordMetrics();
 
-  // processMouseInput processes mouse input from the window on each render loop
-  void processMouseInput();
-
-  // clearScreen clears the screen
-  void clearScreen();
-
-  // render renders the nodes in the engine's scene graph
-  void render();
-
-  // recordMetrics records metrics on each iteration of the render loop.
-  void recordMetrics();
-
-  // runNative runs the render loop on a native platform.
-  void runNative();
+    // runNative runs the render loop on a native platform.
+    void runNative();
 };
 
 /**
@@ -119,11 +119,3 @@ void glfwFramebufferSizeCallback(GLFWwindow *window, int width, int height);
 // The function is called per frame by the browser and yields back control after
 // a single render pass.
 static void runWeb(void *userData);
-
-struct FrameAnalytics {
-private:
-  static glm::vec2 windowSize;
-  static double dpi;
-  static glm::vec2 frameBufferSize;
-  static glm::vec2 viewportSize;
-};

--- a/src/ray.cpp
+++ b/src/ray.cpp
@@ -55,8 +55,6 @@ glm::vec2 getMousePositionFrameBuffer(GLFWwindow *window) {
 
 // frameBufferPosToNDC converts a 2d position vector from frame buffer co-ordinates to NDC
 glm::vec2 frameBufferPosToNDC(glm::vec2 input) {
-  // Convert the coords from screen space to (NDC).
-  // We use the viewport for this, as it uses the framebuffer size
   int viewport[4]; // x, y, w, h
   glGetIntegerv(GL_VIEWPORT, viewport);
 

--- a/src/ray.cpp
+++ b/src/ray.cpp
@@ -30,3 +30,38 @@ glm::vec2 getMousePositionNDC(GLFWwindow *window) {
 
   return glm::vec2(x_ndc, y_ndc);
 }
+
+// getMousePositionFrameBuffer returns the mouse position in frame buffer dimensions.
+glm::vec2 getMousePositionFrameBuffer(GLFWwindow *window) {
+  // Get the mouse position in the window
+  double mouseXWindow, mouseYWindow;
+  glfwGetCursorPos(window, &mouseXWindow, &mouseYWindow);
+
+  // Handle HiDPI: scale screen coords to framebuffer pixels
+  int windowWidth, windowHeight, frameBufferWidth, frameBufferHeight;
+
+  glfwGetWindowSize(window, &windowWidth, &windowHeight);
+  glfwGetFramebufferSize(window, &frameBufferWidth, &frameBufferHeight);
+
+  double scalingFactorX = windowWidth ? (frameBufferWidth / windowWidth) : 1;
+  double scalingFactorY = windowHeight ? (frameBufferHeight / windowHeight) : 1;
+
+  // Scale the mouse coordinates based on the frame buffer size
+  double mouseX = mouseXWindow * scalingFactorX;
+  double mouseY = mouseYWindow * scalingFactorY;
+
+  return glm::vec2{mouseX, mouseY};
+}
+
+// frameBufferPosToNDC converts a 2d position vector from frame buffer co-ordinates to NDC
+glm::vec2 frameBufferPosToNDC(glm::vec2 input) {
+  // Convert the coords from screen space to (NDC).
+  // We use the viewport for this, as it uses the framebuffer size
+  int viewport[4]; // x, y, w, h
+  glGetIntegerv(GL_VIEWPORT, viewport);
+
+  float x_ndc = (2.0f * ((input.x - viewport[0]) / viewport[2])) - 1.0f;
+  float y_ndc = 1.0f - (2.0f * ((input.y - viewport[1]) / viewport[3]));
+
+  return glm::vec2(x_ndc, y_ndc);
+}

--- a/src/ray.h
+++ b/src/ray.h
@@ -8,6 +8,8 @@
 // in normalised device coordinates (NDC) With values in the range [-1, 1].
 glm::vec2 getMousePositionNDC(GLFWwindow *window);
 
+// getMousePositionFrameBuffer returns the mouse position in frame buffer dimensions.
 glm::vec2 getMousePositionFrameBuffer(GLFWwindow *window);
 
+// frameBufferPosToNDC converts a 2d position vector from frame buffer co-ordinates to NDC
 glm::vec2 frameBufferPosToNDC(glm::vec2 input);

--- a/src/ray.h
+++ b/src/ray.h
@@ -7,3 +7,7 @@
 // getMousePositionNDC returns the mouse position within the window
 // in normalised device coordinates (NDC) With values in the range [-1, 1].
 glm::vec2 getMousePositionNDC(GLFWwindow *window);
+
+glm::vec2 getMousePositionFrameBuffer(GLFWwindow *window);
+
+glm::vec2 frameBufferPosToNDC(glm::vec2 input);


### PR DESCRIPTION
This PR fixes an issue where continuous stroke lines were being drawn with gaps. 

This was caused due to the fact that we were previously adding new stroke points in the render loop, which means that we could only add points as frequently as the render loop's run rate / the underlying OpenGL/WebGL render call rate. 

We should instead linearly interpolate between the start and end point for a given drawing session (i.e mouse press) in order to work out the points in the stroke. 

This approach allows us to draw neat continuous stroke without being constrained by the render loop rate.

### ✅ Tested locally on macOS 

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/1856a25e-7257-4fdf-805c-b69cb4bfa759"/> | <video src="https://github.com/user-attachments/assets/7eb9f2e7-8cfc-42e1-8e9d-cb67bdcc1edb"/> | 


